### PR TITLE
Add workflow triggered by Azure alert

### DIFF
--- a/.github/workflows/alert-triggered.yml
+++ b/.github/workflows/alert-triggered.yml
@@ -1,0 +1,13 @@
+name: Triggered by Azure Alert
+
+on:
+  repository_dispatch:
+    types: [azure-alert]
+
+jobs:
+  alertJob:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Alert Azure!
+        run: echo "Hello, world!"


### PR DESCRIPTION
This GitHub Actions workflow runs on a repository_dispatch event with the type 'azure-alert'. It includes a basic job that outputs a greeting message, serving as a placeholder or initial setup for handling Azure alerts.