### PR TITLE
Update Dockerfile to reflect version 1.6

### DIFF
--- a/test-docker/Dockerfile
+++ b/test-docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-LABEL version="1.5"
+LABEL version="1.6"
 LABEL description="Dockerfile di test per pipeline CI/CD."
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
- Bumped the version label in the `Dockerfile` to 1.6. 
- Ensures consistency with the latest software release version.