### PR TITLE
Add Kubernetes deployment for mockapi  

### DIFF
--- a/test-docker/deploy.yml
+++ b/test-docker/deploy.yml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mockapi-deployment
+  labels:
+    app: mockapi
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: mockapi
+  template:
+    metadata:
+      labels:
+        app: mockapi
+    spec:
+      containers:
+        - name: mockapi
+          image: ghcr.io/ffppa/test-runners/test-docker:DEV.latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mockapi-service
+spec:
+  selector:
+    app: mockapi
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: LoadBalancer

--- a/test-docker/src/main.go
+++ b/test-docker/src/main.go
@@ -36,7 +36,7 @@ func main() {
 
 		// Prepare a mock response
 		response := Response{
-			Message: "Example of a mock API!",
+			Message: "Example of a Mock API!",
 			Status:  "success",
 		}
 


### PR DESCRIPTION
Provides Kubernetes deployment and service configuration for `mockapi`, enabling containerized deployment in a Kubernetes cluster. Also updates the mock response text in the `test-docker` setup.