### PR TITLE
Update Dockerfile with version label change

### DIFF
--- a/test-docker/Dockerfile
+++ b/test-docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20-alpine
 
-LABEL version="2.1"
+LABEL version="2.2"
 LABEL description="Dockerfile di test per pipeline CI/CD."
 
 # Copy the Go file into the Docker container


### PR DESCRIPTION
Update the Dockerfile to revise the version label from the previous version to 2.2. This ensures consistency and clarity in identifying the current image version. No changes applied besides the version