### PR TITLE
Add reusable CI/CD workflows for Docker image management

### DIFF
--- a/.github/workflows/ci-cd-paflow/README.md
+++ b/.github/workflows/ci-cd-paflow/README.md
@@ -1,0 +1,68 @@
+### Reusable? Workflows for CI/CD
+
+This repository contains a set of reusable GitHub Actions workflows to standardize and simplify CI/CD processes. These workflows can be used across multiple repositories for building and promoting Docker images.
+
+### Available Workflows
+
+1. **Build PR Docker Image**
+Builds and pushes Docker images tagged for individual Pull Requests (e.g., `pr-<number>`).
+
+2. **Build MAIN Docker Image**
+Builds and pushes a stable Docker image for the `main` branch.
+
+3. **Promote to Environment**
+Promotes a stable Docker image (`stable`) to specific environments (e.g., `uat` or `prod`).
+
+4. **Orchestrator Workflow** 
+Coordinates the above workflows dynamically based on triggers: Pull Requests, `main` branch pushes, or manual actions.
+
+### Example Usage
+Here’s how to invoke the **Orchestrator Workflow**:
+
+
+```
+name: Call OctoPussy Workflow
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Specify promotion target (promote-uat or promote-prod)"
+        required: true
+        type: choice
+        options:
+          - promote-uat
+          - promote-prod
+      stable_tag:
+        description: "The stable Docker tag to promote"
+        required: false
+        default: "stabilisssssimo"
+
+jobs:
+  orchestrator:
+    name: Invoke OctoPussy Workflow
+    uses: pagopa/eng-github-actions-iac-template/.github/workflows/orchestrator.yml@v1.0.0
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      action: ${{ inputs.action }}
+      stable_tag: ${{ inputs.stable_tag }}
+```
+### Inputs for the Orchestrator
+
+| Input | Description | Default |
+| --- | --- | --- |
+| `action` | Target promotion action (, ). `promote-uat``promote-prod` | None |
+| `stable_tag` | The Docker tag to promote. | `stable` |
+
+### How to Trigger Workflows
+1. On **Pull Request**: Automatically builds and tags a Docker image for the PR.
+2. On **Push to Main**: Automatically creates and pushes a stable Docker image.
+3. **Manually**: Navigate to the repository’s Actions tab and trigger the workflow with custom inputs.
+
+This repository offers **centralized, reusable workflows** for scalable and maintainable CI/CD pipelines. Use these workflows to ensure consistency across repositories! 🚀

--- a/.github/workflows/ci-cd-paflow/build-flow/build-main.yml
+++ b/.github/workflows/ci-cd-paflow/build-flow/build-main.yml
@@ -1,0 +1,38 @@
+name: "Build MAIN Docker Image"
+
+on:
+  workflow_call:
+    inputs:
+      github_token:
+        description: "GitHub token for authentication"
+        required: true
+        type: string
+      docker_context_path:
+        description: "Path for the Docker build context"
+        required: false
+        type: string
+        default: "."
+
+jobs:
+  build-main:
+    name: "Build and Push Stable Docker Image"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v4
+
+      - name: "Login to Docker Registry"
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ inputs.github_token }}
+          registry: ghcr.io
+
+      - name: "Build and Push Stable Docker Image"
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.docker_context_path }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:ma-${{ github.event.repository.updated_at }}-${{ github.sha }}

--- a/.github/workflows/ci-cd-paflow/build-flow/build-pr.yml
+++ b/.github/workflows/ci-cd-paflow/build-flow/build-pr.yml
@@ -1,0 +1,46 @@
+name: "Build PR Docker Image"
+
+on:
+  workflow_call:
+    inputs:
+      github_token:
+        description: "GitHub token for authentication"
+        required: true
+        type: string
+      docker_context_path:
+        description: "Path for the Docker build context"
+        required: false
+        type: string
+        default: "."
+      docker_registry:
+        description: "Docker registry for the image"
+        required: false
+        type: string
+        default: "ghcr.io"
+      pr_number:
+        description: "Pull Request number to tag the image"
+        required: true
+        type: string
+
+jobs:
+  build-pr:
+    name: "Build and Push PR Docker Image"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v4
+
+      - name: "Login to Docker Registry"
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ inputs.github_token }}
+          registry: ${{ inputs.docker_registry }}
+
+      - name: "Build and Push PR Docker Image"
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.docker_context_path }}
+          push: true
+          tags: |
+            ${{ inputs.docker_registry }}/${{ github.repository }}:pr-${{ inputs.pr_number }}

--- a/.github/workflows/ci-cd-paflow/orchestrator.yml
+++ b/.github/workflows/ci-cd-paflow/orchestrator.yml
@@ -1,0 +1,50 @@
+name: "Orchestrator Workflow"
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action to execute (promote-uat or promote-prod)"
+        required: true
+        type: choice
+        options:
+          - promote-uat
+          - promote-prod
+      stable_tag:
+        description: "Stable Docker tag to be promoted"
+        required: false
+        default: "stable"
+
+jobs:
+  build-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Build PR Docker Image
+    uses: ./global/build-flow/build-pr.yml
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      docker_context_path: "./" # TODO Examples.
+      docker_registry: "ghcr.io"
+      pr_number: ${{ github.event.number }}
+
+  build-main:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    name: Build Stable Docker Image for Main
+    uses: ./global/build-flow/build-main.yml
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      docker_context_path: "./" # TODO Examples.
+
+  promote:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Promote Docker Image to the Environment
+    uses: ./global/promote/promote-to-environment.yml
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      environment: ${{ github.event.inputs.action == 'promote-uat' && 'uat' || 'prod' }}
+      stable_tag: ${{ github.event.inputs.stable_tag }}

--- a/.github/workflows/ci-cd-paflow/promote/promote-to-environment.yml
+++ b/.github/workflows/ci-cd-paflow/promote/promote-to-environment.yml
@@ -1,0 +1,41 @@
+name: "Promote Docker Image to Environment"
+
+on:
+  workflow_call:
+    inputs:
+      github_token:
+        description: "GitHub token for authentication"
+        required: true
+        type: string
+      environment:
+        description: "Environment to promote to (uat or prod)"
+        required: true
+        type: choice
+        options:
+          - uat
+          - prod
+      stable_tag:
+        description: "The Docker tag to promote (example: stable)"
+        required: true
+        type: string
+
+jobs:
+  promote:
+    name: "Promote Docker Image"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Login to Docker Registry"
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ inputs.github_token }}
+          registry: ghcr.io
+
+      - name: "Pull Stable Image"
+        run: docker pull ghcr.io/${{ github.repository }}:${{ inputs.stable_tag }}
+
+      - name: "Tag Image for ${{ inputs.environment }}"
+        run: docker tag ghcr.io/${{ github.repository }}:${{ inputs.stable_tag }} ghcr.io/${{ github.repository }}:${{ inputs.environment }}
+
+      - name: "Push Image to ${{ inputs.environment }}"
+        run: docker push ghcr.io/${{ github.repository }}:${{ inputs.environment }}


### PR DESCRIPTION
### Description

This pull request introduces reusable CI/CD workflows to streamline Docker image management across the project:

- `build-main.yml`: Builds and pushes stable Docker images for the main branch.
- `build-pr.yml`: Builds and tags Docker images for pull requests.
- `promote-to-environment.yml`: Enables the promotion of Docker images to `uat` or `prod` environments.
- `orchestrator.yml`: Coordinates workflows dynamically based on defined triggers.
- Updated `README.md` to include documentation and examples for using the workflows effectively.

### Checklist

- [ ] Tests added/updated where applicable
- [ ] Documentation updated where applicable
- [ ] Code style and linting checks completed