### PR TITLE
Update test Dockerfile version

### DIFF
--- a/test-docker/Dockerfile
+++ b/test-docker/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20-alpine
 
 # Labels and version
 LABEL version="2.3.1"
-LABEL description="Dockerfile di test per pipeline CI/CD."
+LABEL description="Dockerfile di test per pipeline CI/CD"
 
 # Copy the Go file into the Docker container
 COPY src/main.go .

--- a/test-docker/Dockerfile
+++ b/test-docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.20-alpine
 
+# Labels
 LABEL version="2.3.1"
 LABEL description="Dockerfile di test per pipeline CI/CD."
 

--- a/test-docker/Dockerfile
+++ b/test-docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20-alpine
 
-# Labels
+# Labels and version
 LABEL version="2.3.1"
 LABEL description="Dockerfile di test per pipeline CI/CD."
 

--- a/test-docker/Dockerfile
+++ b/test-docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20-alpine
 
-LABEL version="2.3"
+LABEL version="2.3.1"
 LABEL description="Dockerfile di test per pipeline CI/CD."
 
 # Copy the Go file into the Docker container


### PR DESCRIPTION
Updated the test environment's Dockerfile version label to `2.3.1` to ensure consistency with the current release. No additional functional changes have been made.